### PR TITLE
Fixed condition for new users

### DIFF
--- a/src/scenes/Budgets/containers/TagTable/BudgetPopover.js
+++ b/src/scenes/Budgets/containers/TagTable/BudgetPopover.js
@@ -83,7 +83,7 @@ export default function BudgetPopover({ id, month, onClose, ...rest }) {
       text: getAvgMonthsOutcomeName(prevOutcomes.length),
       amount: +prevMonthsAvgOutcome,
       selected: +value === +prevMonthsAvgOutcome,
-      condition: !!prevMonthsAvgOutcome || prevOutcomes.length < 2,
+      condition: !!prevMonthsAvgOutcome && prevOutcomes.length > 1,
     },
     {
       text: 'Бюджет в прошлом месяце',


### PR DESCRIPTION
Если пользователь новый, на первых двух месяцах бюджетирования он мог увидеть такие предложения:
![image](https://user-images.githubusercontent.com/23480475/107853504-ccd85e80-6e16-11eb-8198-63b51a850324.png)
![image](https://user-images.githubusercontent.com/23480475/107853509-d19d1280-6e16-11eb-9745-836a27bec039.png)

Поправил условие чтобы такого не возникало. Предложения "среднего" теперь будут появляться только когда есть минимум два месяца для расчёта среднего.