### PR TITLE
Вернул округления на место 🙈

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerro",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/src/scenes/Budgets/containers/MonthInfo/CalculationErrorNotice.tsx
+++ b/src/scenes/Budgets/containers/MonthInfo/CalculationErrorNotice.tsx
@@ -13,36 +13,38 @@ import { clearLocalData } from 'logic/localData'
 import { captureError, sendEvent } from 'helpers/tracking'
 import { getDiff } from 'store/data'
 import { getAccountsHistory } from 'scenes/Stats/selectors'
-import { PopulatedAccount } from 'types'
 
-const TOLERANCE = 2
+// TODO: Надо бы как-то округлять все цифры только в конце. Иначе из-за валют копится ошибка.
+const TOLERANCE = 3
 
+/**
+ * Shows error message if sum of accounts in balance is not equal to calculated amount of money in balance. There are 3 main reasons for this:
+ * - Corrupted accounts. For some old acoounts `balance !== startBalance + transactions`. It's known ZM bug.
+ * - Rounding of numbers during the calculations. Numbers are rounded on the each step so it's getting worse with long history and transactions in different currencies. That's why we need some.
+ * - Errors during the calculations.
+ */
 export const CalculationErrorNotice: FC = () => {
   const [hidden, setHidden] = useState(false)
 
-  const transactionsToSync = useSelector(
-    state => getDiff(state)?.transaction?.length || 0
-  )
+  const synced = useSelector(state => !getDiff(state)?.transaction?.length)
   const currency = useSelector(getUserCurrencyCode)
   const dispatch = useDispatch()
 
   const totalsArray = useSelector(getTotalsArray)
   const { moneyInBudget } = totalsArray[totalsArray.length - 1]
 
-  const accsInBudget = useSelector(getInBudgetAccounts)
   const convert = useSelector(convertCurrency)
-  let inBudgetSum = 0
-  accsInBudget.forEach(acc => {
-    const balance = convert(acc.balance, acc.instrument)
-    inBudgetSum = round(inBudgetSum + balance)
-  })
+  const inBudgetSum = useSelector(getInBudgetAccounts).reduce(
+    (sum, acc) => sum + convert(acc.balance, acc.instrument),
+    0
+  )
 
   const diff = round(Math.abs(moneyInBudget - inBudgetSum))
-  const hasError = diff >= TOLERANCE && !transactionsToSync
+  const hasError = diff >= TOLERANCE && synced
 
   useEffect(() => {
     if (hasError) {
-      console.log('🤨 Calc error:', diff, currency)
+      console.warn('🤨 Calc error:', diff, currency)
       captureError(new Error('Calculation Error'), { extra: diff } as any)
       sendEvent('Calculation Error: show message')
     }
@@ -116,17 +118,17 @@ export const CalculationErrorNotice: FC = () => {
 const CorruptedAccounts = () => {
   const histories = useSelector(getAccountsHistory)
   const accounts = useSelector(getInBudgetAccounts)
-  const corrupted: { acc: PopulatedAccount; diff: number }[] = []
-  accounts.forEach(acc => {
-    const history = histories[acc.id]
-    const lastPoint = history.length - 1
-    const diff = Math.abs(history[lastPoint].balance - acc.balance)
-    if (diff > 0.001) {
-      corrupted.push({ acc, diff })
-    }
-  })
+  const corrupted = accounts
+    .map(acc => {
+      const history = histories[acc.id]
+      const lastPoint = history.length - 1
+      const calculatedBalance = history[lastPoint].balance
+      const diff = Math.abs(calculatedBalance - acc.balance)
+      return { acc, diff }
+    })
+    .filter(({ diff }) => diff > 0.001)
 
-  console.log(
+  console.warn(
     'Corrupted accounts:',
     corrupted.map(({ acc, diff }) => ({
       acc: acc.title,

--- a/src/scenes/Budgets/containers/MonthInfo/CalculationErrorNotice.tsx
+++ b/src/scenes/Budgets/containers/MonthInfo/CalculationErrorNotice.tsx
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import { getTotalsArray } from '../../selectors/getTotalsByMonth'
 import { convertCurrency } from 'store/data/selectors'
 import { getInBudgetAccounts } from 'store/localData/accounts'
+import { round } from 'helpers/currencyHelpers'
 import { getUserCurrencyCode } from 'store/data/selectors'
 import { Box, Typography, Button, Link } from '@mui/material'
 import WarningIcon from '@mui/icons-material/Warning'
@@ -14,8 +15,7 @@ import { getDiff } from 'store/data'
 import { getAccountsHistory } from 'scenes/Stats/selectors'
 import { PopulatedAccount } from 'types'
 
-// accaptable error due to roundings in calculations
-const TOLERANCE = 1
+const TOLERANCE = 2
 
 export const CalculationErrorNotice: FC = () => {
   const [hidden, setHidden] = useState(false)
@@ -34,10 +34,10 @@ export const CalculationErrorNotice: FC = () => {
   let inBudgetSum = 0
   accsInBudget.forEach(acc => {
     const balance = convert(acc.balance, acc.instrument)
-    inBudgetSum = inBudgetSum + balance
+    inBudgetSum = round(inBudgetSum + balance)
   })
 
-  const diff = Math.abs(moneyInBudget - inBudgetSum)
+  const diff = round(Math.abs(moneyInBudget - inBudgetSum))
   const hasError = diff >= TOLERANCE && !transactionsToSync
 
   useEffect(() => {

--- a/src/scenes/Budgets/selectors/baseSelectors.ts
+++ b/src/scenes/Budgets/selectors/baseSelectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { getInBudgetAccounts } from 'store/localData/accounts'
 import { convertCurrency } from 'store/data/selectors'
+import { round } from 'helpers/currencyHelpers'
 import { getSortedTransactions } from 'store/localData/transactions'
 import { getStartBalance } from 'store/localData/accounts/helpers'
 import { withPerf } from 'helpers/performance'
@@ -11,7 +12,7 @@ export const getStartFunds = createSelector(
     let sum = 0
     for (const acc of accounts) {
       const startBalance = convert(getStartBalance(acc), acc.instrument) || 0
-      sum = sum + startBalance
+      sum = round(sum + startBalance)
     }
     return sum
   })

--- a/src/scenes/Budgets/selectors/getAmountsByTag.ts
+++ b/src/scenes/Budgets/selectors/getAmountsByTag.ts
@@ -3,6 +3,7 @@ import { getMainTag } from 'store/localData/transactions/helpers'
 import { getTagLinks } from 'store/localData/tags'
 import { convertCurrency } from 'store/data/selectors'
 import { getBudgetsByMonthAndTag } from 'store/localData/budgets'
+import { round } from 'helpers/currencyHelpers'
 import { getAccTagMap } from 'store/localData/hiddenData/accTagMap'
 import startOfMonth from 'date-fns/startOfMonth'
 import { getType } from 'store/localData/transactions/helpers'
@@ -46,28 +47,29 @@ const getAmountsByMonth = createSelector(
 
         if (type === 'income') {
           result[date].income[tag] = result[date].income[tag]
-            ? result[date].income[tag] + income
+            ? round(result[date].income[tag] + income)
             : income
         }
 
         if (type === 'outcome') {
           result[date].outcome[tag] = result[date].outcome[tag]
-            ? result[date].outcome[tag] + outcome
+            ? round(result[date].outcome[tag] + outcome)
             : outcome
         }
 
         if (type === 'transfer') {
           // TRANSFER BETWEEN BUDGET ACCOUNTS
           if (inBudget(tr.incomeAccount) && inBudget(tr.outcomeAccount)) {
-            result[date].transferFees =
+            result[date].transferFees = round(
               result[date].transferFees + outcome - income
+            )
           }
           // TRANSFER TO BUDGET
           else if (inBudget(tr.incomeAccount)) {
             result[date].transfers[tr.outcomeAccount] = result[date].transfers[
               tr.outcomeAccount
             ]
-              ? result[date].transfers[tr.outcomeAccount] - income
+              ? round(result[date].transfers[tr.outcomeAccount] - income)
               : -income
           }
           // TRANSFER FROM BUDGET
@@ -75,7 +77,7 @@ const getAmountsByMonth = createSelector(
             result[date].transfers[tr.incomeAccount] = result[date].transfers[
               tr.incomeAccount
             ]
-              ? result[date].transfers[tr.incomeAccount] + outcome
+              ? round(result[date].transfers[tr.incomeAccount] + outcome)
               : outcome
           }
         }
@@ -105,8 +107,9 @@ export const getLinkedTransfers = createSelector(
       for (const accountId in amounts[date].transfers) {
         // possible problem with deleted tags
         const linkedTag = accTagMap[accountId] || 'null'
-        result[date][linkedTag] =
+        result[date][linkedTag] = round(
           amounts[date].transfers[accountId] + (result[date][linkedTag] || 0)
+        )
       }
     }
     return result
@@ -251,9 +254,9 @@ function calcTagGroupAmounts(data: {
     const income = incomes[childId] || 0
     const tagOutcome = outcomes[childId] || 0
     const transferOutcome = linkedTransfers[childId] || 0
-    const outcome = tagOutcome + transferOutcome
+    const outcome = round(tagOutcome + transferOutcome)
     const leftover = clampAvailable(prevMonth?.children?.[childId]?.available)
-    const available = leftover + budgeted - outcome
+    const available = round(leftover + budgeted - outcome)
 
     subTags[childId] = {
       // Main tag amounts
@@ -281,12 +284,12 @@ function calcTagGroupAmounts(data: {
     }
 
     // Update children totals
-    childrenBudgeted = childrenBudgeted + budgeted
-    childrenOutcome = childrenOutcome + outcome
-    childrenIncome = childrenIncome + income
-    childrenLeftover = childrenLeftover + leftover
-    if (available > 0) childrenAvailable = childrenAvailable + available
-    if (available < 0) childrenOverspent = childrenOverspent - available
+    childrenBudgeted = round(childrenBudgeted + budgeted)
+    childrenOutcome = round(childrenOutcome + outcome)
+    childrenIncome = round(childrenIncome + income)
+    childrenLeftover = round(childrenLeftover + leftover)
+    if (available > 0) childrenAvailable = round(childrenAvailable + available)
+    if (available < 0) childrenOverspent = round(childrenOverspent - available)
   }
 
   // Main tag amounts
@@ -295,17 +298,17 @@ function calcTagGroupAmounts(data: {
   const tagOutcome = outcomes[id] || 0
   let transferOutcome = linkedTransfers[id] || 0 // все переводы идут в null
   if (id === 'null') transferOutcome = 0
-  const outcome = tagOutcome + transferOutcome
+  const outcome = round(tagOutcome + transferOutcome)
   const leftover = clampAvailable(prevMonth?.available)
-  const available = leftover + budgeted - outcome - childrenOverspent
+  const available = round(leftover + budgeted - outcome - childrenOverspent)
 
   return {
     // Group totals
-    totalBudgeted: budgeted + childrenBudgeted,
-    totalOutcome: outcome + childrenOutcome,
-    totalIncome: income + childrenIncome,
-    totalLeftover: leftover + childrenLeftover,
-    totalAvailable: available + childrenAvailable,
+    totalBudgeted: round(budgeted + childrenBudgeted),
+    totalOutcome: round(outcome + childrenOutcome),
+    totalIncome: round(income + childrenIncome),
+    totalLeftover: round(leftover + childrenLeftover),
+    totalAvailable: round(available + childrenAvailable),
     totalOverspent: available < 0 ? -available : 0,
     // Main tag amounts
     budgeted,

--- a/src/scenes/Budgets/selectors/getTotalsByMonth.ts
+++ b/src/scenes/Budgets/selectors/getTotalsByMonth.ts
@@ -5,6 +5,7 @@ import {
   getLinkedTransfers,
   getTransferFees,
 } from './getAmountsByTag'
+import { round } from 'helpers/currencyHelpers'
 import getMonthDates from './getMonthDates'
 import { withPerf } from 'helpers/performance'
 
@@ -50,11 +51,17 @@ export const getTagTotals = createSelector(
       }
 
       for (const id in amounts[month]) {
-        totals.budgeted = totals.budgeted + amounts[month][id].totalBudgeted
-        totals.income = totals.income + amounts[month][id].totalIncome
-        totals.outcome = totals.outcome + amounts[month][id].totalOutcome
-        totals.overspent = totals.overspent + amounts[month][id].totalOverspent
-        totals.available = totals.available + amounts[month][id].totalAvailable
+        totals.budgeted = round(
+          totals.budgeted + amounts[month][id].totalBudgeted
+        )
+        totals.income = round(totals.income + amounts[month][id].totalIncome)
+        totals.outcome = round(totals.outcome + amounts[month][id].totalOutcome)
+        totals.overspent = round(
+          totals.overspent + amounts[month][id].totalOverspent
+        )
+        totals.available = round(
+          totals.available + amounts[month][id].totalAvailable
+        )
       }
       return totals
     })
@@ -100,21 +107,21 @@ export const getTotalsArray = createSelector(
 
           // TO CHECK
           get moneyInBudget() {
-            return this.funds + this.available
+            return round(this.funds + this.available)
           },
 
           realBudgetedInFuture: tagTotals
             .slice(i + 1)
-            .reduce((sum, totals) => sum + totals.budgeted, 0),
+            .reduce((sum, totals) => round(sum + totals.budgeted), 0),
 
           get funds() {
-            return (
+            return round(
               this.prevFunds -
-              this.prevOverspent -
-              this.budgeted +
-              this.income -
-              this.transferOutcome -
-              this.transferFees
+                this.prevOverspent -
+                this.budgeted +
+                this.income -
+                this.transferOutcome -
+                this.transferFees
             )
           },
 


### PR DESCRIPTION
Позже надо будет как-то с этим разобраться.
С одной стороны надо округлять чтобы не натыкаться на `0.1 + 0.2 = 0.30000000000000004` в интерфейсе.
С другой стороны из-за округлений копятся ошибки. На большой мультивалютной истории они могут быть приличными (замеченный рекорд пока 2.11) 