### PR TITLE
Remove scrollbar styling

### DIFF
--- a/src/AppThemeProvider.tsx
+++ b/src/AppThemeProvider.tsx
@@ -29,21 +29,6 @@ const globalStyles = css`
     box-sizing: inherit;
   }
 
-  ::-webkit-scrollbar {
-    width: 12px;
-    height: 12px;
-  }
-
-  ::-webkit-scrollbar-corner {
-    background: var(--c-bg);
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background-color: var(--c-scrollbar);
-    border-radius: 6px;
-    border: 2px solid var(--c-bg);
-  }
-
   .hidden-scroll {
     scrollbar-width: none;
     overflow: -moz-scrollbars-none;


### PR DESCRIPTION
При открытии Popover есть раздражающий сдвиг Drawer. 

![2](https://user-images.githubusercontent.com/59508111/174328754-86fcccd4-1417-4f13-a824-5fd72b8e2869.gif)

Предложение: убрать вообще styling у scrollbar, оставить стиль по умолчанию.