### PR TITLE
fix: styles in budget and transaction

### DIFF
--- a/src/components/DataLine.tsx
+++ b/src/components/DataLine.tsx
@@ -71,6 +71,7 @@ const Dot: FC<DotProps> = ({ color, colorOpacity = 1 }) => (
       marginRight: 8,
       borderRadius: '50%',
       opacity: colorOpacity,
+      flex: '0 0 auto'
     }}
   />
 )

--- a/src/components/TransactionList/Transaction/Transaction.Components.tsx
+++ b/src/components/TransactionList/Transaction/Transaction.Components.tsx
@@ -354,6 +354,18 @@ const AmountsWrapper = styled.div<{
       ? p.theme.palette.text.secondary
       : p.theme.palette.text.primary};
 
+
+  [color="textSecondary"] &[type=transfer] {
+    max-width: 100%;
+    width: 100%;
+    flex-shrink: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    -webkit-mask-image: linear-gradient(to left, transparent, black 40px);
+  }
+
+
   > :not(:first-of-type):before {
     content: '${p => (p.type === 'transfer' ? '→' : '')}';
     margin: 0 4px;
@@ -368,6 +380,7 @@ const InfoWrapper = styled.div`
 
 const PayeeWrapper = styled.span`
   position: relative;
+
   :hover {
     color: ${p => p.theme.palette.text.primary};
   }

--- a/src/components/TransactionList/Transaction/Transaction.tsx
+++ b/src/components/TransactionList/Transaction/Transaction.tsx
@@ -121,6 +121,14 @@ const Row = styled.div`
     mask-image: linear-gradient(to left, transparent, black 40px);
     -webkit-mask-image: linear-gradient(to left, transparent, black 40px);
   }
+
+  > *:first-child:empty {
+    flex-grow: 0;
+  }
+
+  > *:empty + * {
+    margin-left: 0;
+  }
 `
 
 const SecondaryRow = styled(Row)`


### PR DESCRIPTION
Попытался поправить стили в бюджете и в транзакциях. Есть опасения что я не правильно идею понял и наговнокодил. Чет css-in-js как-то все усложняет для понимания.

Было

<img width="324" alt="image" src="https://user-images.githubusercontent.com/11390039/216772790-860cd1be-4242-44e6-bf20-6b58347e1285.png">

Стало

<img width="336" alt="image" src="https://user-images.githubusercontent.com/11390039/216772797-6d160bd1-1a82-4406-b580-2c29941ac4ca.png">


Было

<img width="683" alt="image" src="https://user-images.githubusercontent.com/11390039/216772909-af8c4705-e4eb-424e-bb57-83202e72750e.png">
<img width="522" alt="image" src="https://user-images.githubusercontent.com/11390039/216772934-8ce687e2-306b-46d1-a309-e34313528e1e.png">


Стало

<img width="517" alt="image" src="https://user-images.githubusercontent.com/11390039/216772922-5e391060-e3d7-40db-9215-06a5823729b1.png">

<img width="716" alt="image" src="https://user-images.githubusercontent.com/11390039/216772946-d0114c9e-3ff4-4f3f-9c3e-fcec4498e95c.png">


