### PR TITLE
add expendByDefault to envelopes

### DIFF
--- a/src/2-pages/Budgets/EnvelopeEditDialog/EnvelopeEditDialog.tsx
+++ b/src/2-pages/Budgets/EnvelopeEditDialog/EnvelopeEditDialog.tsx
@@ -69,6 +69,7 @@ export const EnvelopeEditDialog: FC = () => {
       group: envelope?.group || '',
       comment: envelope?.comment || '',
       currency: envelope?.currency || defaultCurrency,
+      expendByDefault: envelope?.expendByDefault || true,
     },
     validate: values => {
       if (!values.originalName.trim()) {
@@ -174,6 +175,13 @@ export const EnvelopeEditDialog: FC = () => {
               name="keepIncome"
               label={t('keepIncomeLabel')}
               checked={values.keepIncome}
+              onChange={handleChange}
+              control={<Checkbox />}
+            />
+            <FormControlLabel
+              name="expendByDefault"
+              label={t('expendByDefaultLabel')}
+              checked={values.expendByDefault}
               onChange={handleChange}
               control={<Checkbox />}
             />

--- a/src/2-pages/Budgets/EnvelopeEditDialog/EnvelopeEditDialog.tsx
+++ b/src/2-pages/Budgets/EnvelopeEditDialog/EnvelopeEditDialog.tsx
@@ -69,7 +69,7 @@ export const EnvelopeEditDialog: FC = () => {
       group: envelope?.group || '',
       comment: envelope?.comment || '',
       currency: envelope?.currency || defaultCurrency,
-      expendByDefault: envelope?.expendByDefault || true,
+      expandByDefault: envelope?.expandByDefault ?? true,
     },
     validate: values => {
       if (!values.originalName.trim()) {
@@ -179,9 +179,9 @@ export const EnvelopeEditDialog: FC = () => {
               control={<Checkbox />}
             />
             <FormControlLabel
-              name="expendByDefault"
-              label={t('expendByDefaultLabel')}
-              checked={values.expendByDefault}
+              name="expandByDefault"
+              label={t('expandByDefaultLabel')}
+              checked={values.expandByDefault}
               onChange={handleChange}
               control={<Checkbox />}
             />

--- a/src/2-pages/Budgets/EnvelopeTable/models/envRenderInfo.ts
+++ b/src/2-pages/Budgets/EnvelopeTable/models/envRenderInfo.ts
@@ -72,6 +72,7 @@ export const getEnvRenderInfo: TSelector<ByMonth<ById<TRenderInfo>>> =
                 hasVisibleChildren
 
           const isDefaultExpanded =
+            (e.expendByDefault === null || e.expendByDefault) &&
             hasChildren &&
             (!isZero(metrics[e.id].childrenLeftover) ||
               !isZero(metrics[e.id].childrenBudgeted) ||

--- a/src/2-pages/Budgets/EnvelopeTable/models/envRenderInfo.ts
+++ b/src/2-pages/Budgets/EnvelopeTable/models/envRenderInfo.ts
@@ -72,7 +72,7 @@ export const getEnvRenderInfo: TSelector<ByMonth<ById<TRenderInfo>>> =
                 hasVisibleChildren
 
           const isDefaultExpanded =
-            (e.expendByDefault === null || e.expendByDefault) &&
+            !(e.expandByDefault === false) &&
             hasChildren &&
             (!isZero(metrics[e.id].childrenLeftover) ||
               !isZero(metrics[e.id].childrenBudgeted) ||

--- a/src/5-entities/envelope/patchEnvelope.ts
+++ b/src/5-entities/envelope/patchEnvelope.ts
@@ -113,7 +113,7 @@ function getChanges(draft: TEnvelopeDraft, envelopes: ById<TEnvelope>) {
       case 'currency':
       case 'keepIncome':
       case 'carryNegatives':
-      case 'expendByDefault':
+      case 'expandByDefault':
         updateMeta(key, draft[key])
         break
 

--- a/src/5-entities/envelope/patchEnvelope.ts
+++ b/src/5-entities/envelope/patchEnvelope.ts
@@ -113,6 +113,7 @@ function getChanges(draft: TEnvelopeDraft, envelopes: ById<TEnvelope>) {
       case 'currency':
       case 'keepIncome':
       case 'carryNegatives':
+      case 'expendByDefault':
         updateMeta(key, draft[key])
         break
 

--- a/src/5-entities/envelope/shared/makeEnvelope.ts
+++ b/src/5-entities/envelope/shared/makeEnvelope.ts
@@ -33,6 +33,7 @@ export type TEnvelope = {
   currency: TFxCode
   keepIncome: boolean
   carryNegatives: boolean
+  expendByDefault: boolean
 }
 
 export const makeEnvelope = {
@@ -66,6 +67,7 @@ type TFuncs = {
   currency: TMaker<TEnvelope['currency']>
   keepIncome: TMaker<TEnvelope['keepIncome']>
   carryNegatives: TMaker<TEnvelope['carryNegatives']>
+  expendByDefault: TMaker<TEnvelope['expendByDefault']>
 }
 
 const funcs: TFuncs = {
@@ -163,6 +165,11 @@ const funcs: TFuncs = {
     account: (el, fx, meta) => meta?.carryNegatives || false,
     debtor: (el, fx, meta) => meta?.carryNegatives || false,
   },
+  expendByDefault: {
+    tag: (el, fx, meta) => meta?.expendByDefault || false,
+    account: (el, fx, meta) => meta?.expendByDefault || false,
+    debtor: (el, fx, meta) => meta?.expendByDefault || false,
+  },
 }
 
 function makeEnvelopeFromTag(
@@ -191,6 +198,7 @@ function makeEnvelopeFromTag(
     currency: funcs.currency.tag(el, userCurrency, meta),
     keepIncome: funcs.keepIncome.tag(el, userCurrency, meta),
     carryNegatives: funcs.carryNegatives.tag(el, userCurrency, meta),
+    expendByDefault: funcs.expendByDefault.tag(el, userCurrency, meta),
   }
 }
 function makeEnvelopeFromAccount(
@@ -219,6 +227,7 @@ function makeEnvelopeFromAccount(
     currency: funcs.currency.account(el, userCurrency, meta),
     keepIncome: funcs.keepIncome.account(el, userCurrency, meta),
     carryNegatives: funcs.carryNegatives.account(el, userCurrency, meta),
+    expendByDefault: funcs.expendByDefault.account(el, userCurrency, meta),
   }
 }
 function makeEnvelopeFromDebtor(
@@ -247,6 +256,7 @@ function makeEnvelopeFromDebtor(
     currency: funcs.currency.debtor(el, userCurrency, meta),
     keepIncome: funcs.keepIncome.debtor(el, userCurrency, meta),
     carryNegatives: funcs.carryNegatives.debtor(el, userCurrency, meta),
+    expendByDefault: funcs.expendByDefault.debtor(el, userCurrency, meta),
   }
 }
 

--- a/src/5-entities/envelope/shared/makeEnvelope.ts
+++ b/src/5-entities/envelope/shared/makeEnvelope.ts
@@ -33,7 +33,7 @@ export type TEnvelope = {
   currency: TFxCode
   keepIncome: boolean
   carryNegatives: boolean
-  expendByDefault: boolean
+  expandByDefault: boolean
 }
 
 export const makeEnvelope = {
@@ -67,7 +67,7 @@ type TFuncs = {
   currency: TMaker<TEnvelope['currency']>
   keepIncome: TMaker<TEnvelope['keepIncome']>
   carryNegatives: TMaker<TEnvelope['carryNegatives']>
-  expendByDefault: TMaker<TEnvelope['expendByDefault']>
+  expandByDefault: TMaker<TEnvelope['expandByDefault']>
 }
 
 const funcs: TFuncs = {
@@ -165,10 +165,10 @@ const funcs: TFuncs = {
     account: (el, fx, meta) => meta?.carryNegatives || false,
     debtor: (el, fx, meta) => meta?.carryNegatives || false,
   },
-  expendByDefault: {
-    tag: (el, fx, meta) => meta?.expendByDefault || false,
-    account: (el, fx, meta) => meta?.expendByDefault || false,
-    debtor: (el, fx, meta) => meta?.expendByDefault || false,
+  expandByDefault: {
+    tag: (el, fx, meta) => meta?.expandByDefault || false,
+    account: (el, fx, meta) => meta?.expandByDefault || false,
+    debtor: (el, fx, meta) => meta?.expandByDefault || false,
   },
 }
 
@@ -198,7 +198,7 @@ function makeEnvelopeFromTag(
     currency: funcs.currency.tag(el, userCurrency, meta),
     keepIncome: funcs.keepIncome.tag(el, userCurrency, meta),
     carryNegatives: funcs.carryNegatives.tag(el, userCurrency, meta),
-    expendByDefault: funcs.expendByDefault.tag(el, userCurrency, meta),
+    expandByDefault: funcs.expandByDefault.tag(el, userCurrency, meta),
   }
 }
 function makeEnvelopeFromAccount(
@@ -227,7 +227,7 @@ function makeEnvelopeFromAccount(
     currency: funcs.currency.account(el, userCurrency, meta),
     keepIncome: funcs.keepIncome.account(el, userCurrency, meta),
     carryNegatives: funcs.carryNegatives.account(el, userCurrency, meta),
-    expendByDefault: funcs.expendByDefault.account(el, userCurrency, meta),
+    expandByDefault: funcs.expandByDefault.account(el, userCurrency, meta),
   }
 }
 function makeEnvelopeFromDebtor(
@@ -256,7 +256,7 @@ function makeEnvelopeFromDebtor(
     currency: funcs.currency.debtor(el, userCurrency, meta),
     keepIncome: funcs.keepIncome.debtor(el, userCurrency, meta),
     carryNegatives: funcs.carryNegatives.debtor(el, userCurrency, meta),
-    expendByDefault: funcs.expendByDefault.debtor(el, userCurrency, meta),
+    expandByDefault: funcs.expandByDefault.debtor(el, userCurrency, meta),
   }
 }
 

--- a/src/5-entities/envelope/shared/metaData.ts
+++ b/src/5-entities/envelope/shared/metaData.ts
@@ -22,7 +22,7 @@ export type TEnvelopeMeta = {
   currency?: TFxCode
   keepIncome?: boolean
   carryNegatives?: boolean
-  expendByDefault?: boolean
+  expandByDefault?: boolean
 }
 
 const envelopeMetaStore = makeSimpleHiddenStore<ById<TEnvelopeMeta>>(

--- a/src/5-entities/envelope/shared/metaData.ts
+++ b/src/5-entities/envelope/shared/metaData.ts
@@ -22,6 +22,7 @@ export type TEnvelopeMeta = {
   currency?: TFxCode
   keepIncome?: boolean
   carryNegatives?: boolean
+  expendByDefault?: boolean
 }
 
 const envelopeMetaStore = makeSimpleHiddenStore<ById<TEnvelopeMeta>>(

--- a/src/6-shared/localization/ru.json
+++ b/src/6-shared/localization/ru.json
@@ -44,6 +44,7 @@
       "hidden": "Всегда скрывать"
     },
     "keepIncomeLabel": "Класть доходы в категорию",
+    "expendByDefaultLabel": "Раскрывать автоматически",
     "btnSave": "Сохранить категорию",
     "btnCreate": "Создать категорию",
     "btnCancel": "Отменить"

--- a/src/6-shared/localization/ru.json
+++ b/src/6-shared/localization/ru.json
@@ -44,7 +44,7 @@
       "hidden": "Всегда скрывать"
     },
     "keepIncomeLabel": "Класть доходы в категорию",
-    "expendByDefaultLabel": "Раскрывать автоматически",
+    "expandByDefaultLabel": "Раскрывать автоматически",
     "btnSave": "Сохранить категорию",
     "btnCreate": "Создать категорию",
     "btnCancel": "Отменить"


### PR DESCRIPTION
Хотелось бы не раскрывать категории на главном экране всегда, если у них есть дочерние.
В категории присутствует чекбокс для такого поведения, по-умолчанию выставлен на раскрытие (сохраняем привычное для юзеров поведение).

Что сделать пока не удалось:
1. Все категории показываются свёрнутыми, если не сохранить индивидуально с этой галкой.
2. Эту галку при редактировании категории имеет наверное смысл отображать лишь для имеющих детей.

Мой первый опыт с react вообще и первый опыт с фронтом за 6 лет, прошу простить наивность.