### PR TITLE
Popover stack close fix

### DIFF
--- a/src/6-shared/historyPopovers/popoverStack.ts
+++ b/src/6-shared/historyPopovers/popoverStack.ts
@@ -35,10 +35,13 @@ function useActions(): {
       },
       close: (key: TKey) => {
         if (!key) return
-        const stack = getStack(history.location)
-        const lastIndex = stack.indexOf(key)
+        const currStack = getStack(history.location)
+        const lastIndex = currStack.indexOf(key)
         if (lastIndex === -1) return
-        history.go(lastIndex - stack.length)
+
+        const { pathname, hash, search, state = {} } = history.location
+        const prevState = {...state, dialogs: currStack[0] === key ? [] : currStack.slice(0, lastIndex)}
+        history.replace(pathname + hash + search, prevState)
       },
     }),
     [history]

--- a/src/6-shared/historyPopovers/popoverStack.ts
+++ b/src/6-shared/historyPopovers/popoverStack.ts
@@ -35,13 +35,10 @@ function useActions(): {
       },
       close: (key: TKey) => {
         if (!key) return
-        const currStack = getStack(history.location)
-        const lastIndex = currStack.indexOf(key)
+        const stack = getStack(history.location)
+        const lastIndex = stack.indexOf(key)
         if (lastIndex === -1) return
-
-        const { pathname, hash, search, state = {} } = history.location
-        const prevState = {...state, dialogs: currStack[0] === key ? [] : currStack.slice(0, lastIndex)}
-        history.replace(pathname + hash + search, prevState)
+        history.go(lastIndex - stack.length)
       },
     }),
     [history]

--- a/src/6-shared/ui/SmartSelect.tsx
+++ b/src/6-shared/ui/SmartSelect.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { MenuList, Select, SelectProps } from '@mui/material'
+import {
+  FormControl,
+  InputLabel,
+  MenuList,
+  Select,
+  SelectProps
+} from '@mui/material'
 import { popoverStack } from '6-shared/historyPopovers'
 
 import { SwipeableDrawer, Theme, useMediaQuery } from '@mui/material'
@@ -12,7 +18,8 @@ export function SmartSelect<T>(props: TSmartSelectProps<T>) {
   const isMobile = useMediaQuery<Theme>(theme => theme.breakpoints.down('sm'))
 
   return (
-    <>
+    <FormControl>
+      {props.label && <InputLabel>{props.label}</InputLabel>}
       <Select
         {...selectProps}
         open={isMobile ? false : open}
@@ -74,6 +81,6 @@ export function SmartSelect<T>(props: TSmartSelectProps<T>) {
           </MenuList>
         </SwipeableDrawer>
       )}
-    </>
+    </FormControl>
   )
 }


### PR DESCRIPTION
Браузер хром.

1. Заходишь zerro.app.
2. Переходишь в любой раздел, предположим "Аналитика".
3. Переходишь в бюджеты, выбираешь любой конверт
4. Нажимаешь кнопку изменить.
5. Выбираешь "что делать с категорией", выбираешь любую
6. Тебя перекидывает на страницу Аналитики.

Работает на самом деле с любым popover'ом. Самое простое - правая кнопка мыши на счёт, ткнуть кнопку - перекинет на другую страницу.

Вот что говорит chatGPT:

```
• В Chrome history.pushState() при вызове с тем же URL, но только с изменённым объектом state заменяет (replace) текущую запись, а не создаёт новую  ￼.
• Safari же в аналогичной ситуации добавляет дубликат записи, поэтому у вас в одном браузере «тянет» стек вниз, а в другом — нет.
• Из-за этого history.go() «никуда не уходит» в Chrome (нет дополнительных записей в стеке), и ваш метод close() действительно не срабатывает.
```

Дополнительно пофиксил лейблы на select-контролах в модале редактирования категории