### PR TITLE
fix(tag): fallback to use `title` if `name` is empty

### DIFF
--- a/src/5-entities/envelope/shared/makeEnvelope.ts
+++ b/src/5-entities/envelope/shared/makeEnvelope.ts
@@ -92,7 +92,7 @@ const funcs: TFuncs = {
     debtor: el => (el.merchantId ? EnvType.Merchant : EnvType.Payee),
   },
   name: {
-    tag: el => el.name,
+    tag: el => el.name || el.title,
     account: el => el.title,
     debtor: el => el.name,
   },


### PR DESCRIPTION
### Problem:
Если имя категории состоит из одной emoji, то `name` у неё пустой.

<img width="259" alt="Screenshot 2025-05-25 at 23 31 09" src="https://github.com/user-attachments/assets/0eecc8c9-278f-40be-a83a-0fb53504d294" />

### Fix:
Если поле `name` пустое, берем значение `title`

### Context:
Пример _нормальной_ категории:
<img width="355" alt="Screenshot 2025-05-25 at 23 45 39" src="https://github.com/user-attachments/assets/3676793e-982d-489b-ad63-51c978ed41d8" />

Пример категории с названием из одного emoji:
<img width="333" alt="Screenshot 2025-05-25 at 23 46 21" src="https://github.com/user-attachments/assets/0bc5cf3f-bfa4-404f-9c28-dfa5afeb94e6" />


### Result:
<img width="240" alt="Screenshot 2025-05-25 at 23 29 19" src="https://github.com/user-attachments/assets/af3eccdc-eba7-45b5-bfa9-1e9fea84cf31" />
