### PR TITLE
Fix translation key progressOnTarget

### DIFF
--- a/src/4-features/bulkActions/fillGoals/ui/GoalsProgress.tsx
+++ b/src/4-features/bulkActions/fillGoals/ui/GoalsProgress.tsx
@@ -56,7 +56,7 @@ export const GoalsProgress: FC<TGoalsProgressProps> = props => {
   return (
     <Tooltip
       arrow
-      title={t('progressOnTagret', {
+      title={t('progressOnTarget', {
         budgeted: formatSum(targetValue - needValue),
         target: formatSum(targetValue),
       })}

--- a/src/6-shared/localization/translations/en.ts
+++ b/src/6-shared/localization/translations/en.ts
@@ -372,7 +372,7 @@ export const en: typeof ru = {
 
   goals: {
     goalType: 'Type of goal',
-    progressOnTagret: '{{budgeted}} out of {{target}}',
+    progressOnTarget: '{{budgeted}} out of {{target}}',
     names: {
       monthly: 'Regular savings',
       monthlySpend: 'Monthly amount',

--- a/src/6-shared/localization/translations/ru.json
+++ b/src/6-shared/localization/translations/ru.json
@@ -353,7 +353,7 @@
 
   "goals": {
     "goalType": "Тип цели",
-    "progressOnTagret": "{{budgeted}} из {{target}}",
+    "progressOnTarget": "{{budgeted}} из {{target}}",
     "names": {
       "monthly": "Регулярные сбережения",
       "monthlySpend": "Сумма на месяц",


### PR DESCRIPTION
## Summary
- rename `progressOnTagret` translation key to `progressOnTarget`
- reference the new key in `GoalsProgress`

## Testing
- `pnpm run lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm run test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6846e85867f4832788c86509985494ac