### PR TITLE
Fix #98: comment can't be deleted via bulk edit

### DIFF
--- a/src/3-widgets/transaction/TransactionList/TopBar/BulkEditModal.test.tsx
+++ b/src/3-widgets/transaction/TransactionList/TopBar/BulkEditModal.test.tsx
@@ -1,0 +1,102 @@
+import '@testing-library/jest-dom'
+import type { TTransaction } from '6-shared/types'
+import { configureStore } from '@reduxjs/toolkit'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Provider } from 'react-redux'
+import i18n from 'i18next'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+import dataReducer from 'store/data'
+import { trModel } from '5-entities/transaction'
+import { BulkEditModal } from './BulkEditModal'
+
+beforeAll(async () => {
+  await i18n.changeLanguage('en')
+})
+
+const makeTr = (id: string, comment: string | null): TTransaction =>
+  trModel.makeTransaction({
+    id,
+    user: 0,
+    date: '2022-10-20',
+    incomeInstrument: 2,
+    incomeAccount: 'acc1',
+    outcomeInstrument: 2,
+    outcomeAccount: 'acc1',
+    outcome: 100,
+    comment,
+  })
+
+const createTestStore = (transactions: TTransaction[]) =>
+  configureStore({
+    reducer: { data: dataReducer },
+    preloadedState: {
+      data: {
+        current: {
+          serverTimestamp: 0,
+          instrument: {},
+          country: {},
+          company: {},
+          user: {},
+          merchant: {},
+          account: {},
+          tag: {},
+          budget: {},
+          reminder: {},
+          reminderMarker: {},
+          transaction: Object.fromEntries(transactions.map(tr => [tr.id, tr])),
+        },
+      },
+    },
+  })
+
+const getComment = (store: ReturnType<typeof createTestStore>, id: string) =>
+  store.getState().data.current.transaction[id].comment
+
+const commentField = () => screen.getByRole('textbox')
+const saveButton = () => screen.getByRole('button', { name: 'Apply Changes' })
+
+/**
+ * The modal lives permanently in the tree and gets ids only when the user
+ * selects transactions, so tests open it the same way the app does.
+ */
+const renderAndOpen = (
+  store: ReturnType<typeof createTestStore>,
+  ids: string[]
+) => {
+  const modal = (props: { ids: string[]; open: boolean }) => (
+    <Provider store={store}>
+      <BulkEditModal {...props} onClose={vi.fn()} onApply={vi.fn()} />
+    </Provider>
+  )
+  const { rerender } = render(modal({ ids: [], open: false }))
+  rerender(modal({ ids, open: true }))
+}
+
+describe('BulkEditModal', () => {
+  test('shows the current comment of the selected transaction', () => {
+    const store = createTestStore([makeTr('tr1', 'Old comment')])
+    renderAndOpen(store, ['tr1'])
+    expect(commentField()).toHaveValue('Old comment')
+  })
+
+  test('clears the comment when the field is emptied', async () => {
+    const store = createTestStore([makeTr('tr1', 'Old comment')])
+    renderAndOpen(store, ['tr1'])
+    await userEvent.clear(commentField())
+    await userEvent.click(saveButton())
+    expect(getComment(store, 'tr1')).toBe(null)
+  })
+
+  test('does not touch comments when the field is left untouched', async () => {
+    const store = createTestStore([
+      makeTr('tr1', 'One'),
+      makeTr('tr2', 'Another'),
+    ])
+    renderAndOpen(store, ['tr1', 'tr2'])
+    await userEvent.click(saveButton())
+    expect(getComment(store, 'tr1')).toBe('One')
+    expect(getComment(store, 'tr2')).toBe('Another')
+  })
+})

--- a/src/3-widgets/transaction/TransactionList/TopBar/BulkEditModal.tsx
+++ b/src/3-widgets/transaction/TransactionList/TopBar/BulkEditModal.tsx
@@ -39,23 +39,26 @@ export const BulkEditModal: FC<BulkEditModalProps> = ({
   const types = getTypes(transactions)
   const tagType = types.income ? (types.outcome ? null : 'income') : 'outcome'
   const commonTags = sameTags ? transactions[0]?.tag || [] : ['mixed']
+  const commonComment = sameComments ? transactions[0]?.comment || '' : ''
 
   const [tags, setTags] = useState(commonTags)
-  const [comment, setComment] = useState(
-    sameComments ? transactions[0]?.comment || '' : ''
-  )
+  const [comment, setComment] = useState(commonComment)
 
   useEffect(() => {
-    if (open) setTags(commonTags)
+    if (open) {
+      setTags(commonTags)
+      setComment(commonComment)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setTags, ids, open])
+  }, [setTags, setComment, ids, open])
 
   const onSave = () => {
     const opts = {
       tags: equalArrays(commonTags, tags) ? undefined : tags,
-      comment,
+      // An empty comment is a valid change, so untouched means `undefined`
+      comment: comment === commonComment ? undefined : comment,
     }
-    if (opts.tags || opts.comment) {
+    if (opts.tags || opts.comment !== undefined) {
       dispatch(trModel.bulkEditTransactions(ids, opts))
     }
     onApply()

--- a/src/5-entities/transaction/thunks.test.ts
+++ b/src/5-entities/transaction/thunks.test.ts
@@ -1,0 +1,72 @@
+import type { TTransaction } from '6-shared/types'
+import { configureStore } from '@reduxjs/toolkit'
+import { describe, expect, test } from 'vitest'
+import dataReducer from 'store/data'
+import { makeTransaction } from './makeTransaction'
+import { bulkEditTransactions } from './thunks'
+
+const makeTr = (comment: string | null): TTransaction =>
+  makeTransaction({
+    id: 'tr1',
+    user: 0,
+    date: '2022-10-20',
+    incomeInstrument: 2,
+    incomeAccount: 'acc1',
+    outcomeInstrument: 2,
+    outcomeAccount: 'acc1',
+    outcome: 100,
+    tag: ['tag1'],
+    comment,
+  })
+
+const createTestStore = (tr: TTransaction) =>
+  configureStore<{ data: ReturnType<typeof dataReducer> }, any>({
+    reducer: { data: dataReducer },
+    preloadedState: {
+      data: {
+        current: {
+          serverTimestamp: 0,
+          instrument: {},
+          country: {},
+          company: {},
+          user: {},
+          merchant: {},
+          account: {},
+          tag: {},
+          budget: {},
+          reminder: {},
+          reminderMarker: {},
+          transaction: { [tr.id]: tr },
+        },
+      },
+    },
+  })
+
+const getComment = (store: ReturnType<typeof createTestStore>) =>
+  store.getState().data.current.transaction.tr1.comment
+
+describe('bulkEditTransactions', () => {
+  test('sets a comment', () => {
+    const store = createTestStore(makeTr(null))
+    store.dispatch(bulkEditTransactions(['tr1'], { comment: 'New comment' }))
+    expect(getComment(store)).toBe('New comment')
+  })
+
+  test('clears a comment when an empty string is passed', () => {
+    const store = createTestStore(makeTr('Old comment'))
+    store.dispatch(bulkEditTransactions(['tr1'], { comment: '' }))
+    expect(getComment(store)).toBe(null)
+  })
+
+  test('keeps the comment when it is not passed', () => {
+    const store = createTestStore(makeTr('Old comment'))
+    store.dispatch(bulkEditTransactions(['tr1'], { tags: ['tag2'] }))
+    expect(getComment(store)).toBe('Old comment')
+  })
+
+  test('supports the $& placeholder for the previous comment', () => {
+    const store = createTestStore(makeTr('Old comment'))
+    store.dispatch(bulkEditTransactions(['tr1'], { comment: '$& and more' }))
+    expect(getComment(store)).toBe('Old comment and more')
+  })
+})

--- a/src/5-entities/transaction/thunks.ts
+++ b/src/5-entities/transaction/thunks.ts
@@ -144,8 +144,9 @@ const modifyTags = (prevTags: string[] | null, newTags?: string[]) => {
   return result
 }
 const modifyComment = (prevComment: string | null, newComment?: string) => {
-  if (!newComment) return prevComment
-  return newComment.replaceAll('$&', prevComment || '')
+  // Only an omitted comment means "keep the old one". An empty string clears it.
+  if (newComment === undefined) return prevComment
+  return newComment.replaceAll('$&', prevComment || '') || null
 }
 
 function split(raw: TTransaction) {


### PR DESCRIPTION
Fixes #98.

## What happens

Erasing a comment in the **Edit transactions** dialog (select transactions → Actions → Edit) silently does nothing — the transaction keeps its old comment. On top of that, the dialog never shows the comment of the currently selected transactions, which is the second half of the report ("при редактировании операции комментарий не отображается").

Editing the same transaction through the transaction preview panel works fine, which is why the bug only shows up on this path.

## Root cause

An empty string was treated as "no change" in two independent places:

1. `BulkEditModal.onSave` — `if (opts.tags || opts.comment)` skipped the dispatch entirely when the only change was clearing the comment.
2. `modifyComment` in `5-entities/transaction/thunks.ts` — `if (!newComment) return prevComment` restored the previous comment even if the dispatch did happen.

And a third, related one: `comment` was only initialised on mount. `BulkEditModal` lives permanently in the tree (rendered by `Actions` with `ids={[]}` before anything is selected), so the field started empty and then kept whatever was typed the previous time. The `useEffect` on `open` reset `tags` but not `comment`.

## The fix

- `modifyComment` keeps the previous comment only when the new one is `undefined`; an empty string clears it and is stored as `null`, matching the `comment: string | null` convention in `makeTransaction`. The `$&` placeholder keeps working.
- `BulkEditModal` sends `comment` only when it differs from the common comment of the selection — the same guard tags already use. So hitting Save without touching the field never overwrites anything, including when a mixed selection shows an empty field.
- The comment field is reset when the dialog opens, so it shows the actual comment of the selected transactions.

## Tests

Added `thunks.test.ts` and `BulkEditModal.test.tsx` covering set / clear / untouched / `$&` placeholder. Both fail before the change and pass after.

Also verified by hand in demo mode: clearing a comment now removes it from the list immediately, and other transactions are untouched.

Note: `src/5-entities/tag/ui/TagSelect2.test.tsx` fails on `master` already (its `vi.mock('i18next')` has no default export, so `6-shared/localization` blows up on import). Left it alone to keep this PR focused — happy to fix it separately if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)