### PR TITLE
chore(transaction): убрать мёртвое правило :empty в строках списка операций

### DIFF
--- a/src/3-widgets/transaction/TransactionList/Transaction/Transaction.tsx
+++ b/src/3-widgets/transaction/TransactionList/Transaction/Transaction.tsx
@@ -121,10 +121,6 @@ const Row = styled.div`
     mask-image: linear-gradient(to left, transparent, black 40px);
     -webkit-mask-image: linear-gradient(to left, transparent, black 40px);
   }
-
-  > *:empty + * {
-    margin-left: 0;
-  }
 `
 
 const SecondaryRow = styled(Row)`


### PR DESCRIPTION
Небольшая уборка стилей в строке операции. Ref #142.

В `Row` осталось правило-хвост:

```css
> *:empty + * {
  margin-left: 0;
}
```

Оно было парой к `> *:first-child:empty { flex-grow: 0 }` — тому самому правилу, из-за которого название счёта «съезжало» влево у операций без плательщика и комментария (#142). Второе правило удалено в 335a6b704aac2bb3c1b4448e1efee72a98691314, а первое осталось и теперь ни на что не влияет: пустой первый блок снова растягивается через `flex-grow: 1`, поэтому `margin-left` соседа не виден в любом случае.

## Проверка

Собрал изолированный репро с тремя вариантами CSS и замерил правую границу блока со счётом (ширина ряда 448px):

```
right edges — old: withInfo=448 empty=100 | master: withInfo=448 empty=448 | PR: withInfo=448 empty=448
```

- `old` — состояние на момент создания #142, счёт уезжает влево;
- `master` — сейчас, всё выровнено;
- `PR` — после удаления правила, разметка не меняется.

`tsc --noEmit` проходит.

Сам баг из #142 уже исправлен в `master`, так что ишью можно закрывать независимо от этого PR — здесь только чистка мёртвого CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
