### PR TITLE
fix: don't write "mixed" tag placeholder when bulk editing transactions

### DIFF
--- a/src/5-entities/transaction/thunks.test.ts
+++ b/src/5-entities/transaction/thunks.test.ts
@@ -1,0 +1,51 @@
+import type { TTagId } from '6-shared/types'
+import { describe, expect, test } from 'vitest'
+import { store } from 'store'
+import { applyClientPatch } from 'store/data'
+import { makeTransaction } from './makeTransaction'
+import { getTransactionsById } from './model'
+import { bulkEditTransactions } from './thunks'
+
+function makeTr(id: string, tag: TTagId[] | null) {
+  return makeTransaction({
+    id,
+    user: 0,
+    date: '2024-01-01',
+    incomeInstrument: 2,
+    incomeAccount: 'acc',
+    outcomeInstrument: 2,
+    outcomeAccount: 'acc',
+    outcome: 100,
+    tag,
+  })
+}
+
+describe('bulkEditTransactions', () => {
+  test('adds a tag keeping own tags of every transaction', () => {
+    store.dispatch(
+      applyClientPatch({
+        transaction: [makeTr('tr1', ['tag1']), makeTr('tr2', ['tag2'])],
+      })
+    )
+    store.dispatch(
+      bulkEditTransactions(['tr1', 'tr2'], { tags: ['mixed', 'tag3'] })
+    )
+    const transactions = getTransactionsById(store.getState())
+    expect(transactions.tr1.tag).toEqual(['tag1', 'tag3'])
+    expect(transactions.tr2.tag).toEqual(['tag2', 'tag3'])
+  })
+
+  test('never writes the "mixed" placeholder to a transaction without tags', () => {
+    store.dispatch(
+      applyClientPatch({
+        transaction: [makeTr('tr3', ['tag1']), makeTr('tr4', null)],
+      })
+    )
+    store.dispatch(
+      bulkEditTransactions(['tr3', 'tr4'], { tags: ['mixed', 'tag3'] })
+    )
+    const transactions = getTransactionsById(store.getState())
+    expect(transactions.tr3.tag).toEqual(['tag1', 'tag3'])
+    expect(transactions.tr4.tag).toEqual(['tag3'])
+  })
+})

--- a/src/5-entities/transaction/thunks.ts
+++ b/src/5-entities/transaction/thunks.ts
@@ -138,7 +138,8 @@ const modifyTags = (prevTags: string[] | null, newTags?: string[]) => {
   const addId = (id: string) =>
     result.includes(id) || id === 'null' ? '' : result.push(id)
   newTags?.forEach(id => {
-    if (id === 'mixed' && prevTags) prevTags.forEach(addId)
+    // 'mixed' is a placeholder for the transaction's own tags, never a real id
+    if (id === 'mixed') prevTags?.forEach(addId)
     else addId(id)
   })
   return result


### PR DESCRIPTION
Fixes #147

## Проблема

При массовом редактировании операций с разными категориями модалка подставляет служебный тег `mixed` («Разные категории»), который при сохранении должен раскрываться в собственные категории каждой операции. Но если у операции категории нет вообще, `prevTags === null`, и проверка

```js
if (id === 'mixed' && prevTags) prevTags.forEach(addId)
else addId(id)
```

уходит в `else`, записывая строку `'mixed'` в операцию как настоящий id категории.

После этого `usePopulatedTags()['mixed']` возвращает `undefined`, и рендер списка операций падает в `Symbol` (`Transaction.Components.tsx`) на `tag.symbol` — приложение целиком уходит в error boundary («Что-то навернулось… `dt is undefined`»).

## Фикс

`'mixed'` раскрывается в собственные теги операции независимо от того, есть они или нет: `if (id === 'mixed') prevTags?.forEach(addId)`.

## Тесты

Добавлен `src/5-entities/transaction/thunks.test.ts` — два кейса на `bulkEditTransactions`: обычное добавление категории к операциям с разными категориями и кейс из issue (одна операция без категории). Второй тест падает без фикса (`expected [ 'mixed', 'tag3' ] to deeply equal [ 'tag3' ]`) и проходит с ним.

`npx tsc --noEmit` чистый. `npx vitest run` — 17 тестов проходят; `TagSelect2.test.tsx` падает на этапе загрузки (мок `i18next` без `default`-экспорта) — это воспроизводится и на `master` без этих изменений, к PR не относится.

🤖 Generated with [Claude Code](https://claude.com/claude-code)