### PR TITLE
fix: reset highlighted categories on year switch

### DIFF
--- a/src/2-pages/Review/cards/IncomeCard/IncomeCard.tsx
+++ b/src/2-pages/Review/cards/IncomeCard/IncomeCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Box, Typography, Chip, Stack } from '@mui/material'
 import { entries } from '6-shared/helpers/keys'
 import { addFxAmount } from '6-shared/helpers/money'
@@ -34,6 +34,13 @@ export function IncomeCard(props: TCardProps) {
     .sort((a, b) => b.income - a.income)
 
   const [checked, setChecked] = useState(incomeTags.map(t => t.id))
+
+  const incomeIdsKey = incomeTags.map(t => t.id).join(',')
+
+  useEffect(() => {
+    setChecked(incomeTags.map(t => t.id))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [incomeIdsKey])
 
   const totalIncomeFx = incomeTags
     .filter(t => checked.includes(t.id))

--- a/src/2-pages/Review/cards/NotFunCard/NotFunCard.tsx
+++ b/src/2-pages/Review/cards/NotFunCard/NotFunCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   Box,
   Checkbox,
@@ -37,6 +37,18 @@ export function NotFunCard(props: TCardProps) {
   const { income, outcome } = useIncomeOutcome(onlyRUB, props.year)
   const [checkedIncome, setCheckedIncome] = useState(income.map(t => t.id))
   const [checkedOutcome, setCheckedOutcome] = useState(outcome.map(t => t.id))
+
+  const incomeIdsKey = income.map(t => t.id).join(',')
+  const outcomeIdsKey = outcome.map(t => t.id).join(',')
+
+  useEffect(() => {
+    setCheckedIncome(income.map(t => t.id))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [incomeIdsKey])
+  useEffect(() => {
+    setCheckedOutcome(outcome.map(t => t.id))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [outcomeIdsKey])
 
   const [displayCurr] = displayCurrency.useDisplayCurrency()
   if (displayCurr !== 'RUB') return null


### PR DESCRIPTION
checked state in IncomeCard and NotFunCard was initialized once at mount, so switching years left stale selections: categories present in the new year but absent from the initial render stayed unhighlighted and were excluded from the totals. Reset the selection to all categories whenever the set of category ids changes.